### PR TITLE
Mobile version

### DIFF
--- a/src/components/Grid/Flex.jsx
+++ b/src/components/Grid/Flex.jsx
@@ -10,6 +10,7 @@ Flex.displayName = `Flex`
 
 Flex.defaultProps = {
   display: `flex`,
+  'flex-wrap': 'wrap',
 }
 
 Flex.propTypes = {


### PR DESCRIPTION
I don't know where exactly problem in components, I think it here. 
So on mobile version, div with classes 'sc-bdVaJa sc-bwzfXH degOVg' displays overflow and make horizontal scroll. I defined that there is display flex, so if add a pror flex-wrap: wrap it will be show correctly on mobile device.